### PR TITLE
Allow numbers read from file to contain '+'.

### DIFF
--- a/stl/ascii.py
+++ b/stl/ascii.py
@@ -131,7 +131,7 @@ class Scanner(object):
         start_col = self.peeked_col
         while True:
             b = self.peek_byte()
-            if b.isdigit() or b == '.' or b == '-' or b == 'e':
+            if b.isdigit() or b == '.' or b == '+' or b == '-' or b == 'e':
                 ret_bytes.append(self.get_byte())
             else:
                 break

--- a/tests/test_ascii.py
+++ b/tests/test_ascii.py
@@ -23,11 +23,11 @@ class TestScanner(unittest.TestCase):
         return tokens
 
     def test_numbers(self):
-        tokens = self._get_tokens("1 0.1 -0.1 1e2\n1.2e2 1.2e-2")
+        tokens = self._get_tokens("1 0.1 -0.1 1e2\n1.2e2 1.2e-2 1.2e+2")
         self.assertEqual(
             tokens,
             [
-                1, 0.1, -0.1, 100, 120, 0.012,
+                1, 0.1, -0.1, 100, 120, 0.012, 120.0,
             ],
         )
 


### PR DESCRIPTION
This is valid in Python string to float conversion and is found in STL
files generated by several programs.

e.g. '321e+5'
