### PR TITLE
Implements reading a binary STL's header

### DIFF
--- a/stl/binary.py
+++ b/stl/binary.py
@@ -40,7 +40,8 @@ class Reader(object):
 
     def read_header(self):
         bytes = self.read_bytes(80)
-        return struct.unpack('80s', bytes)[0]
+        return struct.unpack('80s', bytes)[0].strip('\0')
+
 
 class FormatError(ValueError):
     pass

--- a/stl/binary.py
+++ b/stl/binary.py
@@ -38,6 +38,9 @@ class Reader(object):
         z = self.read_float()
         return Vector3d(x, y, z)
 
+    def read_header(self):
+        bytes = self.read_bytes(80)
+        return struct.unpack('80s', bytes)[0]
 
 class FormatError(ValueError):
     pass
@@ -46,10 +49,9 @@ class FormatError(ValueError):
 def parse(file):
     r = Reader(file)
 
-    ret = Solid()
+    name = r.read_header()[6:]
 
-    # Skip the header
-    r.read_bytes(80)
+    ret = Solid(name=name)
 
     num_facets = r.read_uint32()
 

--- a/stl/types.py
+++ b/stl/types.py
@@ -5,9 +5,7 @@ class Solid(object):
     A solid object; the root element of an STL file.
     """
 
-    #: The name given to the object by the ASCII file header.
-    #: Always ``None`` for objects read from binary files, since the binary
-    #: format has no such concept.
+    #: The name given to the object by the STL file header.
     name = None
 
     #: :py:class:`list` of :py:class:`stl.Facet` objects representing the

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -3,8 +3,8 @@ from StringIO import StringIO
 import unittest
 from stl.binary import *
 
-
 EMPTY_HEADER = '\0' * 80
+T_HDR = '\x73\x6f\x6c\x69\x64\x20\x54\x65\x73\x74\x66\x69\x6c\x65' + ('\0'*66)
 
 
 class TestParser(unittest.TestCase):
@@ -18,12 +18,12 @@ class TestParser(unittest.TestCase):
 
     def test_no_facets(self):
         solid = self._parse_str(
-            EMPTY_HEADER + '\0\0\0\0'
+            T_HDR + '\0\0\0\0'
         )
         self.assertEqual(
             solid,
             Solid(
-                name=None,
+                name='Testfile',
                 facets=[],
             ),
         )
@@ -33,12 +33,12 @@ class TestParser(unittest.TestCase):
             # Declared that we have two facets but we
             # actually have none.
             self._parse_str(
-                EMPTY_HEADER + '\x02\x00\x00\x00'
+                T_HDR + '\x02\x00\x00\x00'
             )
 
     def test_valid(self):
         solid = self._parse_str(
-            EMPTY_HEADER +
+            T_HDR +
             '\x02\x00\x00\x00'  # two facets
             # first facet
             '\x00\x00\x80\x3f'  # normal x = 1.0
@@ -73,7 +73,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(
             solid,
             Solid(
-                name=None,
+                name='Testfile',
                 facets=[
                     Facet(
                         normal=Vector3d(1.0, 2.0, 3.0),


### PR DESCRIPTION
For binary STLs, the header is an 80 byte string of the form:

solid NameOfTheSolidHere

This library now parses that header and sets the `Solid.name`
property accordingly.
The original documentation read that binary STLs have no concept
of an object name. However, Wikipedia[0] suggests that some binary
STL files still use a header that begins 'solid '. In fact, exporting
from FreeCAD[1] results in a binary STL that has a fleshed out header.

[0] https://en.wikipedia.org/wiki/STL_%28file_format%29#Binary_STL
[1] http://freecadweb.org/

Signed-off-by: zachwick zach@zachwick.com
