### PR TITLE
Fixed issue with exponent byte capitlization

### DIFF
--- a/stl/ascii.py
+++ b/stl/ascii.py
@@ -131,7 +131,7 @@ class Scanner(object):
         start_col = self.peeked_col
         while True:
             b = self.peek_byte()
-            if b.isdigit() or b == '.' or b == '+' or b == '-' or b == 'e':
+            if b.isdigit() or b == '.' or b == '+' or b == '-' or b == 'e' or b == 'E':
                 ret_bytes.append(self.get_byte())
             else:
                 break


### PR DESCRIPTION
ASCII .stl files with capitalized exponent bytes ('E' vs. 'e') were returning an error.
