### PR TITLE
Implements reading the facet attribute bytes

### DIFF
--- a/stl/binary.py
+++ b/stl/binary.py
@@ -61,14 +61,20 @@ def parse(file):
         vertices = tuple(
             r.read_vector3d() for j in xrange(0, 3)
         )
+
+        attr_byte_count = r.read_uint16()
+        if attr_byte_count > 0:
+            # Some modeling software uses the attribute bytes for various
+            # purposes, so don't skip attribute bytes
+            attr_bytes = r.read_bytes(attr_byte_count)
+        else:
+            attr_bytes = None
+            
         ret.add_facet(
             normal=normal,
             vertices=vertices,
+            attributes=attr_bytes,
         )
-        attr_byte_count = r.read_uint16()
-        if attr_byte_count > 0:
-            # skip attribute bytes
-            r.read_bytes(attr_byte_count)
 
     return ret
 

--- a/stl/types.py
+++ b/stl/types.py
@@ -71,6 +71,11 @@ class Facet(object):
     A facet (triangle) from a :py:class:`stl.Solid`.
     """
 
+    #: The uint16 of 'attribute bytes'. By the STL spec, these are unused and
+    #: are generally supposed to both be \0. However, some modeling software
+    #: uses them for various purposes.
+    attributes = None
+
     #: The 'normal' vector of the facet, as a :py:class:`stl.Vector3d`.
     normal = None
 
@@ -78,7 +83,7 @@ class Facet(object):
     #: facet's three vertices, in order.
     vertices = None
 
-    def __init__(self, normal, vertices):
+    def __init__(self, normal, vertices, attributes=None):
         self.normal = Vector3d(*normal)
         self.vertices = tuple(
             Vector3d(*x) for x in vertices

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -82,6 +82,7 @@ class TestParser(unittest.TestCase):
                             Vector3d(7.0, 8.0, 9.0),
                             Vector3d(10.0, 11.0, 12.0),
                         ),
+                        attributes='\x00\x00\x80\x7f',
                     ),
                     Facet(
                         normal=Vector3d(1.0, 1.0, 1.0),
@@ -90,6 +91,7 @@ class TestParser(unittest.TestCase):
                             Vector3d(1.0, 1.0, 1.0),
                             Vector3d(1.0, 1.0, 1.0),
                         ),
+                        attributes=None,
                     ),
                 ],
             ),
@@ -125,6 +127,7 @@ class TestWriter(unittest.TestCase):
                             Vector3d(7.0, 8.0, 9.0),
                             Vector3d(10.0, 11.0, 12.0),
                         ),
+                        attributes=None,
                     ),
                     Facet(
                         normal=Vector3d(1.0, 1.0, 1.0),
@@ -133,6 +136,7 @@ class TestWriter(unittest.TestCase):
                             Vector3d(1.0, 1.0, 1.0),
                             Vector3d(1.0, 1.0, 1.0),
                         ),
+                        attributes=None,
                     ),
                 ],
             ),


### PR DESCRIPTION
The binary version of the STL file format allows a 2-byte unsigned
integer that serves as the 'attribute byte count.' This is ususally 0,
but some modelling software puts non-zero values in for various
undocumented purposes.

Note that the ASCII version of the STL file format does not have an
attribute byte count field.

Signed-off-by: zachwick zach@zachwick.com

Handles case where there are no attribute bytes

Signed-off-by: zachwick zach@zachwick.com

Tests for attribute bytes now pass

Signed-off-by: zachwick zach@zachwick.com
